### PR TITLE
update ntttp.c

### DIFF
--- a/src/ntttcp.c
+++ b/src/ntttcp.c
@@ -66,12 +66,12 @@ struct ntttcp_test_endpoint *new_ntttcp_test_endpoint(struct ntttcp_test *test, 
 		else
 			total_threads = test->parallel * test->conn_per_thread + 1;
 
-		e->client_streams = (struct ntttcp_stream_client **) malloc( sizeof( struct  ntttcp_stream_client ) * total_threads );
+		e->client_streams = (struct ntttcp_stream_client **) malloc( sizeof( struct  ntttcp_stream_client *) * total_threads );
 		if(!e->client_streams) {
 			free (e);
 			return NULL;
 		}
-		memset(e->client_streams, 0, sizeof( struct  ntttcp_stream_client ) * total_threads );
+		memset(e->client_streams, 0, sizeof( struct  ntttcp_stream_client *) * total_threads );
 		for(i = 0; i < total_threads ; i++ ) {
 			e->client_streams[i] = new_ntttcp_client_stream(test);
 		}
@@ -92,12 +92,12 @@ struct ntttcp_test_endpoint *new_ntttcp_test_endpoint(struct ntttcp_test *test, 
 		else
 			total_threads = test->parallel + 1;
 
-		e->server_streams = (struct  ntttcp_stream_server **) malloc( sizeof( struct  ntttcp_stream_server ) * total_threads );
+		e->server_streams = (struct  ntttcp_stream_server **) malloc( sizeof( struct  ntttcp_stream_server *) * total_threads );
 		if(!e->server_streams) {
 			free (e);
 			return NULL;
 		}
-		memset(e->server_streams, 0, sizeof( struct  ntttcp_stream_server) * total_threads );
+		memset(e->server_streams, 0, sizeof( struct  ntttcp_stream_server *) * total_threads );
 		for(i = 0; i < total_threads; i++ ){
 			e->server_streams[i] = new_ntttcp_server_stream(test);
 		}


### PR DESCRIPTION
Maybe this is not a bug, just spelling mistake.
e->client_streams is a pointer to pointer of ntttcp_stream_client.
(1)e->client_streams = (struct ntttcp_stream_client **) malloc( sizeof( struct  ntttcp_stream_client *) * total_threads );
alloc an array of ntttcp_stream_client pointer.
(2)e->client_streams[i] = new_ntttcp_client_stream(test);
alloc a ntttcp_stream_client struct.